### PR TITLE
Add recursive flag and update wildcard search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Ignore CSV results from test runs
+*.csv

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ dat -u username
 
 ### Options:
 ```
-usage: dehashapitool [-h] [-a ADDRESS] [-e EMAIL] [-H HASHED_PASSWORD] [-i IP_ADDRESS] [-n NAME] [-p PASSWORD] [-P PHONE] [-u USERNAME] [-v VIN] [-d DOMAIN] [-o OUTPUT] [-oS OUTPUT_SILENTLY]
-                     [-s SIZE] [--only-passwords] [--regex] [--key [DEHASHED_KEY]] [--store-key]
+usage: dehashapitool [-h] [-a ADDRESS] [-e EMAIL] [-H HASHED_PASSWORD] [-i IP_ADDRESS] [-n NAME] [-p PASSWORD] [-P PHONE] [-u USERNAME]
+                     [-v VIN] [-d DOMAIN] [-o OUTPUT] [-oS OUTPUT_SILENTLY] [-s SIZE] [--only-passwords] [--regex] [--recursive]
+                     [--key [DEHASHED_KEY]] [--store-key]
 
 Query the Dehashed API
 
@@ -79,6 +80,7 @@ options:
   -s SIZE, --size SIZE  Specify the size, between 1 and 10000
   --only-passwords      Return only passwords
   --regex               Use regex search instead of string (seems to be broken as of May 2025)
+  --recursive           Automaitically make unlimited recursive API calls for full query data (BE CAREFUL)
 
 API Arguments:
   Arguments related to Dehashed API credentials
@@ -133,7 +135,7 @@ The above will return all passwords for the queried domain, sorted alphabeticall
 
 The above will return 10 results utilizing the wildcard
 
-> **Note**: As of May 2025, the wildcard search using "*" seems to be broken in the V2 API.
+> **Note**: As of July 2025, the wildcard search using "*" works in some cases but will also often times throw unexpected errors or results in false negatives.
 
 ## Contributions
 Contributions are always welcome! Please open an issue or submit a pull request.

--- a/dehashapitool/run.py
+++ b/dehashapitool/run.py
@@ -30,12 +30,10 @@ def build_query(args):
                             wildcard = True
                         if not args.regex and "*" in value:  # At the time of writing (MAy 2025) searches using "*" seems to be broken
                             print(f"  {RED}[!] Searching using \"*\" seems to be broken in the Dehashed API side (as of May 2025). Use \"?\" instead of single character wildcards{RESET}") 
-                            while True:
-                                proceed = input("    [-] Would you like to continue with the request (y/n): ")
-                                if proceed.lower() == "y" or proceed.lower()== "yes":
-                                    break
-                                if proceed.lower() == "n" or proceed.lower()== "no":
-                                    exit()
+                            if accept_prompt(prompt='    [-] Would you like to continue with the request (y/n): '):
+                                break
+                            else:
+                                exit()
                         continue
 
                 if not args.regex:
@@ -43,7 +41,7 @@ def build_query(args):
                         wildcard = True
                 
                 if key == 'domain':
-                    queries.append(f"{key}:{value}")  # Domains will not except searches in quotes
+                    queries.append(f"{key}:{value}")  # Domains will not accept searches in quotes
                     continue
 
                 queries.append(f"{key}:\"{value}\"")
@@ -211,18 +209,27 @@ def recursive_search(query: str, size: int, wildcard: bool, regex: bool, api_key
         # Sanity check calls to prevent burning all you API keys
         if not unlimited_calls and (total / size) > 25:
             api_calls = math.ceil(total / size)
-            while True:
-                proceed = input(f"  {RED}[!] You are about to make {api_calls} API calls. Are you sure you want to continue? (y/n): {RESET}")
-                if proceed.lower() == "y" or proceed.lower()== "yes":
-                    unlimited_calls = True
-                    break
-                if proceed.lower() == "n" or proceed.lower()== "no":
-                    exit()
+            api_call_prompt = f"  {RED}[!] You are about to make {api_calls} API calls. Are you sure you want to continue? (y/n): {RESET}"
+            if accept_prompt(prompt=api_call_prompt):
+                unlimited_calls = True
+            else:
+                exit()
 
         # Avoid breaking DeHashed ratelimit
         sleep(0.1)
 
     return balance, entries
+
+
+def accept_prompt(prompt: str) -> bool:
+    while True:
+        proceed = input(prompt)
+        if proceed.lower() == "y" or proceed.lower()== "yes":
+            return True
+        elif proceed.lower() == "n" or proceed.lower()== "no":
+            return False
+        else:
+            print(f"  {RED}[!] Input not recognized. Please input \"y\" or \"n\": {RESET}")
 
 def main():
     args = load_args()

--- a/dehashapitool/run.py
+++ b/dehashapitool/run.py
@@ -94,6 +94,7 @@ def load_args():
     parser.add_argument('--only-passwords', action="store_true", help="Return only passwords")
     parser.add_argument('--regex', action="store_true", help="Use regex search instead of string (seems to be broken as of May 2025)")
     parser.add_argument('--recursive', action="store_true", help="Automaitically make unlimited recursive API calls for full query data (BE CAREFUL)")
+    parser.add_argument('--summary', action="store_true", help="Display summary of results rather than printing them to the screen (Use with -o flag)")
 
     # Dehashed API credential arguments
     api_group = parser.add_argument_group('API Arguments', 'Arguments related to Dehashed API credentials')
@@ -143,6 +144,10 @@ def load_args():
     if not 1 <= args.size <= 10000:
         parser.error("[!] Size value should be between 1 and 10000.")
         exit()
+
+    if args.summary and not args.output:
+        prompt = f"  {RED}[!] Summary was selected but no output was set; you will not save the search results. Are you sure you want to proceed? (y/n): {RESET}"
+        exit() if not accept_prompt(prompt) else None
     
     return args
 
@@ -256,9 +261,13 @@ def main():
     elif not args.output_silently:
         for key in sorted_keys:
             values = list(set([flatten_list(entry[key]).lower() for entry in entries if key in entry and entry[key]]))
-            if values:
-                values.sort()
-                print(f"\n  {BLUE}[{key}s]{RESET}: {', '.join(values)}")
+
+            if args.summary:
+                print(f"  {BLUE}[{key}s]{RESET}: {len(values)}")
+            else:
+                if values:
+                    values.sort()
+                    print(f"\n  {BLUE}[{key}s]{RESET}: {', '.join(values)}")
 
     if not args.output_silently:
         print(f"\n{GREY}[-] You have {balance} API credits remaining.{RESET}")

--- a/dehashapitool/run.py
+++ b/dehashapitool/run.py
@@ -18,33 +18,14 @@ def build_query(args):
     queries = []
     wildcard = False
     for key, value in vars(args).items():
-        if key in ['address', 'email', 'hashed_password', 'ip_address', 'name', 'password', 'phone', 'username', 'vin', 'domain']:                    
+        if key in ['address', 'email', 'hashed_password', 'ip_address', 'name', 'password', 'phone', 'username', 'vin', 'domain']:
             if value:
-                if key == 'email':
-                    # Regexing/Wildcarding emails requires that you split the query into email and domain.
-                    if check_wildcard(value) or args.regex:
-                        email, domain = value.split("@")
-                        queries.append(f"email:{email}@{domain}")
-                        queries.append(f"domain:{domain}")
-                        if not args.regex:
-                            wildcard = True
-                        if not args.regex and "*" in value:  # At the time of writing (MAy 2025) searches using "*" seems to be broken
-                            print(f"  {RED}[!] Searching using \"*\" seems to be broken in the Dehashed API side (as of May 2025). Use \"?\" instead of single character wildcards{RESET}") 
-                            if accept_prompt(prompt='    [-] Would you like to continue with the request (y/n): '):
-                                break
-                            else:
-                                exit()
-                        continue
+                if not args.regex and check_wildcard(value):
+                    wildcard = True
+                    if not accept_prompt(prompt='  [!] As of July 2025, wildcard API calls sometimes yield false negatives and errors. Would you like to proceed (y/n)?: '):
+                        exit()
 
-                if not args.regex:
-                    if check_wildcard(value):
-                        wildcard = True
-                
-                if key == 'domain':
-                    queries.append(f"{key}:{value}")  # Domains will not accept searches in quotes
-                    continue
-
-                queries.append(f"{key}:\"{value}\"")
+                queries.append(f"{key}:{value}")
     
     return "&".join(queries), wildcard
 

--- a/dehashapitool/run.py
+++ b/dehashapitool/run.py
@@ -285,7 +285,12 @@ def main():
                 writer = csv.DictWriter(csvfile, fieldnames=sorted_all_keys)
                 writer.writeheader()
                 for entry in sorted(entries, key=lambda x: flatten_list(x.get(primary_key, "")).lower()):
-                    writer.writerow({k: flatten_list(entry[k]) for k in sorted_all_keys if k in entry and entry[k] and entry[k] != "null"})
+                    if args.domain:
+                        row = {k: flatten_list(entry[k]) for k in sorted_all_keys if k in entry and entry[k] and entry[k] != "null"}
+                        row['domain'] = args.domain
+                        writer.writerow(row)
+                    else:
+                        writer.writerow({k: flatten_list(entry[k]) for k in sorted_all_keys if k in entry and entry[k] and entry[k] != "null"})
 
     if args.output_silently:
         print(f"\n{GREY}[-] Results returned and saved in {args.output_silently}{RESET}")


### PR DESCRIPTION
# Overview and Purpose
This PR addresses the issues I raised (Issues #8  and #9) where the limit flag was ignored, and wildcard search has been updated. Unfortunately, the wildcard search *still* seems to be broken; however, I found it does work in some cases. 

# Changes
Here is the following list of changes:

 - Added recursive flag and prompt before automatic recursive calls
 - Added a y/n prompt function to cleanup code
 - Updated the wildcard search logic now that wildcards are _partly_ working.

# Bugs
I've tested this PR on a Ubuntu 22.04 via WSL environment, but as always, an error or bug may have slipped through. My testing was mainly focused on the email and domain flags, and I only lightly tested other types of searches.